### PR TITLE
Rnn bookkeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ tape:backward()
 Note: I don't actually use the gradients at all here, and I don't set them to zero first, just to keep the example simple.
 See also [our nngraph practical](https://github.com/oxford-cs-ml-2015/practical5/blob/master/practical5.pdf) for the equivalent in `nngraph`.
 
+
+### RNN Example
+
+See the [examples folder](examples/) for a [fully functional rnn example](examples/rnn_example.lua) with toy data.
+
 ### LSTM example
 The LSTM example <https://github.com/oxford-cs-ml-2015/practical6> can easily be shortened by using this. We delete the backward pass, and simply play it back from the recorded forward pass:
 ```lua

--- a/examples/rnn_example.lua
+++ b/examples/rnn_example.lua
@@ -41,7 +41,6 @@ local model = {
 		for i = 1, inputs:size(1) do
 			output, next_state = unpack(self.rnn:forward({inputs[i], next_state}))
 			loss = loss + self.criterion:forward(output, targets[i])
-			self.tape:step()
 		end
 
 		self.tape:stop()

--- a/examples/rnn_example.lua
+++ b/examples/rnn_example.lua
@@ -1,0 +1,92 @@
+require 'nn'
+require 'nngraph'
+require 'autobw'
+require 'math'
+require 'optim'
+
+local n_input = 1
+local n_output = 1
+local n_hidden = 25
+local batch_size = 15
+local seq_length = 25
+
+local function make_rnn(n_input, n_hidden, n_output)
+	local input = nn.Identity()()
+	local prev_state = nn.Identity()()
+
+	local next_state = nn.Sigmoid()(nn.CAddTable()({
+		nn.Linear(n_input, n_hidden)(input),
+		nn.Linear(n_hidden, n_hidden)(prev_state)
+	}))
+
+	local output = nn.Linear(n_hidden, n_output)(next_state)
+
+	return nn.gModule({input, prev_state}, {output, next_state})
+end
+
+local model = {
+	rnn = make_rnn(n_input, n_hidden, n_output),
+	criterion = nn.MSECriterion(),
+
+	start_state = torch.zeros(batch_size, n_hidden),
+
+	tape = autobw.Tape(),
+
+	forward = function(self, inputs, targets)
+		local loss = 0
+		local next_state = self.start_state
+
+		self.tape:start()
+
+		for i = 1, inputs:size(1) do
+			output, next_state = unpack(self.rnn:forward({inputs[i], next_state}))
+			loss = loss + self.criterion:forward(output, targets[i])
+			self.tape:step()
+		end
+
+		self.tape:stop()
+
+		return loss
+	end,
+
+	backward = function(self)
+		self.tape:backward()
+	end,
+}
+
+local data = torch.linspace(0, 20*math.pi, 1000):sin():view(-1, 1)
+
+local function next_batch()
+	local batch = torch.zeros(seq_length, batch_size, 1)
+	local start_idx = torch.Tensor(batch_size):uniform():mul(data:size(1) - seq_length):ceil():long()
+	for i = 1, batch_size do
+		batch:select(2, i):copy(data:sub(start_idx[i], start_idx[i]+seq_length-1))
+	end
+	return batch
+end
+
+local params, grads = model.rnn:getParameters()
+params:uniform(-0.1, 0.1)
+
+local function fopt(x)
+	if params ~= x then
+		params:copy(x)
+	end
+	grads:zero()
+
+	local batch = next_batch()
+	local inputs = batch:sub(1, batch:size(1)-1)
+	local targets = batch:sub(2, batch:size(1))
+
+	local loss = model:forward(inputs, targets)
+	model:backward()
+
+	return loss, grads
+end
+
+for i = 1, 10000 do
+	local _, fx = optim.sgd(fopt, params, {})
+	print(fx[1])
+end
+
+

--- a/tape.lua
+++ b/tape.lua
@@ -27,9 +27,11 @@ function Tape:__init()
 end
 
 function Tape:reset()
-    -- Clear the internal cache of cloned modules.
+    self.tape = {}
     self._clones = {}
     self._next_clone_idx = {}
+    self._x_to_dx = {}
+    self._zeros = {}
     collectgarbage()
 end
 

--- a/tape.lua
+++ b/tape.lua
@@ -131,7 +131,6 @@ function Tape:backward()
 
         if dinput then
             zip_foreach(o.input, dinput, function(x, dx)
-                assert(self._x_to_dx[ptr(x)] == nil)
                 self._x_to_dx[ptr(x)] = dx
             end)
         end

--- a/tape.lua
+++ b/tape.lua
@@ -44,7 +44,7 @@ function Tape:_adjoint(x)
         return mapping[ptr(x)] or self:_zero(x)
     elseif utils.istable(x) then
         local ret = {}
-        for  = 1, #x do
+        for i = 1, #x do
             if utils.istensor(x[i]) then
                 ret[i] = mapping[ptr(x[i])] or self:_zero(x[i])
             else

--- a/utils.lua
+++ b/utils.lua
@@ -13,5 +13,47 @@ function utils.istable(x)
     return type(x) == 'table' and not torch.typename(x)
 end
 
+function utils.shared_clone(net)
+    local params, gradParams
+    if net.parameters then
+        params, gradParams = net:parameters()
+        if params == nil then
+            params = {}
+        end
+    end
+
+    local paramsNoGrad
+    if net.parametersNoGrad then
+        paramsNoGrad = net:parametersNoGrad()
+    end
+
+    local mem = torch.MemoryFile("w"):binary()
+    mem:writeObject(net)
+
+    local reader = torch.MemoryFile(mem:storage(), "r"):binary()
+    local clone = reader:readObject()
+    reader:close()
+
+    if net.parameters then
+        local cloneParams, cloneGradParams = clone:parameters()
+        local cloneParamsNoGrad
+        for i = 1, #params do
+            cloneParams[i]:set(params[i])
+            cloneGradParams[i]:set(gradParams[i])
+        end
+        if paramsNoGrad then
+            cloneParamsNoGrad = clone:parametersNoGrad()
+            for i =1,#paramsNoGrad do
+                cloneParamsNoGrad[i]:set(paramsNoGrad[i])
+            end
+        end
+    end
+
+    mem:close()
+    return clone
+end
+
+
+
 return utils
 


### PR DESCRIPTION
This PR adds some bookkeeping to the Tape class to keep track of cloning modules for BPTT.

Instead of manually cloning all of the modules in your network for each time step, now you can just call tape:step() to advance time and re-use the same modules at each time step.  The clones of each module are stored internally in `_clones` and will be re-used unless you clear them with `tape:reset()`.
